### PR TITLE
KRACOEUS-8915:Treat JPA IndirectList like ArrayList for serialization

### DIFF
--- a/rice-framework/krad-service-impl/src/main/java/org/kuali/rice/krad/service/impl/SerializerServiceBase.java
+++ b/rice-framework/krad-service-impl/src/main/java/org/kuali/rice/krad/service/impl/SerializerServiceBase.java
@@ -75,6 +75,12 @@ public abstract class SerializerServiceBase implements SerializerService  {
         } catch ( Exception ex ) {
         	// Do nothing - this will blow if the OJB class does not exist, which it won't in some installs
         }
+        try {
+        	Class<?> jpaIndirectListClass = Class.forName("org.eclipse.persistence.indirection.IndirectList");
+        	xstream.addDefaultImplementation(ArrayList.class, jpaIndirectListClass);
+        } catch ( Exception ex ) {
+        	// Do nothing if JPA isn't included
+        }
         xstream.registerConverter(new AutoPopulatingListConverter(xstream.getMapper()));
         xstream.registerConverter(new DateTimeConverter());
     }


### PR DESCRIPTION
During KEW serialization of the document for document content, PD was serializing JPAs indirectlist proxy instead of the actual list and contents.