### PR TITLE
RESKC-225: unmodifiable list change

### DIFF
--- a/rice-middleware/core/api/src/main/java/org/kuali/rice/core/api/criteria/GenericQueryResults.java
+++ b/rice-middleware/core/api/src/main/java/org/kuali/rice/core/api/criteria/GenericQueryResults.java
@@ -28,12 +28,12 @@ import java.util.List;
 
 public final class GenericQueryResults<T> implements QueryResults<T> {
 
-	private final List<T> results;
+	private List<T> results;
 	private final Integer totalRowCount;
 	private final boolean moreResultsAvailable;
 	
 	private GenericQueryResults(Builder<T> builder) {
-		this.results = builder.getResults() != null ? Collections.unmodifiableList(new ArrayList<T>(builder.getResults())) : Collections.<T>emptyList();
+		this.results = builder.getResults() != null ? new ArrayList<T>(builder.getResults()) : new ArrayList<T>();
 		this.totalRowCount = builder.getTotalRowCount();
 		this.moreResultsAvailable = builder.isMoreResultsAvailable();
 	}


### PR DESCRIPTION
This is a server side change but it has really been causing a lot of pain and I would really like to see rice fix this (either by making the list mutable or by giving alternate methods that return mutable lists) if KC is not going to make server side changes. If we are opposed to making server side changes at this time, my other option is to wrap the unmodifiable collection in an ArrayList on the client side rice code. Let me know what you think