### PR TITLE
Fix Agenda Editor persistence issue

### DIFF
--- a/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/ui/AgendaEditorMaintainable.java
+++ b/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/ui/AgendaEditorMaintainable.java
@@ -25,7 +25,6 @@ import org.kuali.rice.core.api.uif.RemotableTextInput;
 import org.kuali.rice.core.api.util.tree.Node;
 import org.kuali.rice.core.api.util.tree.Tree;
 import org.kuali.rice.core.impl.cache.DistributedCacheManagerDecorator;
-import org.kuali.rice.krad.data.PersistenceOption;
 import org.kuali.rice.krad.maintenance.Maintainable;
 import org.kuali.rice.krad.maintenance.MaintainableImpl;
 import org.kuali.rice.krad.maintenance.MaintenanceDocument;
@@ -33,7 +32,6 @@ import org.kuali.rice.krad.uif.container.Container;
 import org.kuali.rice.krad.uif.view.View;
 import org.kuali.rice.krad.uif.view.ViewModel;
 import org.kuali.rice.krad.util.KRADConstants;
-import org.kuali.rice.krad.util.ObjectUtils;
 import org.kuali.rice.krad.web.form.MaintenanceDocumentForm;
 import org.kuali.rice.krms.api.KrmsConstants;
 import org.kuali.rice.krms.api.repository.action.ActionDefinition;
@@ -474,6 +472,7 @@ public class AgendaEditorMaintainable extends MaintainableImpl {
                 newTerm.setDescription(propositionBo.getNewTermDescription());
                 newTerm.setSpecificationId(termSpecId);
                 newTerm.setId(termIdIncrementer.getNewId());
+                newTerm.getSpecification().setId(newTerm.getSpecificationId());
 
                 List<TermParameterBo> params = new ArrayList<TermParameterBo>();
                 for (Map.Entry<String, String> entry : propositionBo.getTermParameters().entrySet()) {


### PR DESCRIPTION
Need to set the ID on TermBo's TermSpecificationBo, or else a new ID will be incorrectly assigned when the TermBo is persisted.

This fixes an issue where creating a new Agenda containing Question terms (and possibly others) causes the Agenda Editor maint doc to go into exception routing with this error:

java.sql.SQLIntegrityConstraintViolationException: ORA-01400: cannot insert NULL into ("KR"."KRMS_TERM_SPEC_T"."NM")